### PR TITLE
Implement logging with an attribute, following the aspect-oriented programming principle

### DIFF
--- a/dotnetTemplate.Application/Helpers/BaseHelper.cs
+++ b/dotnetTemplate.Application/Helpers/BaseHelper.cs
@@ -1,7 +1,9 @@
+using dotnetTemplate.Core.Attributes;
 using dotnetTemplate.Core.Interfaces.Helpers;
 
 namespace dotnetTemplate.Application.Helpers;
 
+[LogAndMeasure]
 public abstract class BaseHelper : IBaseHelper
 {
     

--- a/dotnetTemplate.Application/Services/BaseService.cs
+++ b/dotnetTemplate.Application/Services/BaseService.cs
@@ -1,7 +1,9 @@
+using dotnetTemplate.Core.Attributes;
 using dotnetTemplate.Core.Interfaces.Services;
 
 namespace dotnetTemplate.Application.Services;
 
+[LogAndMeasure]
 public abstract class BaseService : IBaseService
 {
     

--- a/dotnetTemplate.Core/Attributes/LogAndMeasureAttribute.cs
+++ b/dotnetTemplate.Core/Attributes/LogAndMeasureAttribute.cs
@@ -1,0 +1,26 @@
+using System.Diagnostics;
+using AspectInjector.Broker;
+
+namespace dotnetTemplate.Core.Attributes;
+
+[Aspect(Scope.Global)]
+[Injection(typeof(LogAndMeasureAttribute))]
+public class LogAndMeasureAttribute : Attribute
+{
+    [Advice(Kind.Around, Targets = Target.Method)]
+    public object LogAndMeasure(
+        [Argument(Source.Type)] Type type,
+        [Argument(Source.Name)] string name,
+        [Argument(Source.Target)] Func<object[], object> methodDelegate,
+        [Argument(Source.Arguments)] object[] args)
+    {
+        Console.WriteLine($"[{DateTime.UtcNow}] Calling '{name}' method...");
+        
+        Stopwatch sw = Stopwatch.StartNew();
+        object result = methodDelegate(args);
+        sw.Stop();
+        
+        Console.WriteLine($"[{DateTime.UtcNow}] Method '{name}' finished in {sw.ElapsedMilliseconds} ms.");
+        return result;
+    }
+}

--- a/dotnetTemplate.Core/dotnetTemplate.Core.csproj
+++ b/dotnetTemplate.Core/dotnetTemplate.Core.csproj
@@ -6,4 +6,8 @@
         <Nullable>enable</Nullable>
     </PropertyGroup>
 
+    <ItemGroup>
+      <PackageReference Include="AspectInjector" Version="2.8.2" />
+    </ItemGroup>
+
 </Project>

--- a/dotnetTemplate.Gateways/Clients/BaseClient.cs
+++ b/dotnetTemplate.Gateways/Clients/BaseClient.cs
@@ -1,7 +1,9 @@
+using dotnetTemplate.Core.Attributes;
 using dotnetTemplate.Core.Interfaces.Clients;
 
 namespace dotnetTemplate.Gateways.Clients;
 
+[LogAndMeasure]
 public abstract class BaseClient : IBaseClient
 {
     

--- a/dotnetTemplate.Persistence/Repositories/BaseRepository.cs
+++ b/dotnetTemplate.Persistence/Repositories/BaseRepository.cs
@@ -1,7 +1,9 @@
+using dotnetTemplate.Core.Attributes;
 using dotnetTemplate.Core.Interfaces.Repositories;
 
 namespace dotnetTemplate.Persistence.Repositories;
 
+[LogAndMeasure]
 public abstract class BaseRepository : IBaseRepository
 {
     

--- a/dotnetTemplate.Persistence/UnitOfWork.cs
+++ b/dotnetTemplate.Persistence/UnitOfWork.cs
@@ -1,7 +1,9 @@
+using dotnetTemplate.Core.Attributes;
 using dotnetTemplate.Core.Interfaces;
 
 namespace dotnetTemplate.Persistence;
 
+[LogAndMeasure]
 public class UnitOfWork : IUnitOfWork
 {
     


### PR DESCRIPTION
Using the AspectInjector open-source library, we can implement logging by using the aspect-oriented programming principle.

It helps to keep the code readable by separating the "main" code from cross-cutting concerns such as logging. Now you can simply use the [LogAndMeasure] attribute on any method or class to log and measure the execution time of each method!

The logging has been implemented using the console, but you can of course use any logging library instead. Here are some useful resources if you want to do so:
- How to use AspectInjector with dependency injection: https://github.com/pamidur/aspect-injector/discussions/166
- Aspect-oriented programming with AspectInjector in .NET (an example of how to implement logging using ILogger): https://medium.com/@yurexus/aspect-oriented-programming-in-net-with-aspectinjector-cb56d8f80254
- AspectInjector on GitHub (there are some basic but useful usage examples): https://github.com/pamidur/aspect-injector